### PR TITLE
Recover from a broken Cn

### DIFF
--- a/pystdf/IO.py
+++ b/pystdf/IO.py
@@ -160,6 +160,10 @@ class Parser(DataSource):
           if len(fields) < len(recType.columnNames):
             fields += [None] * (len(recType.columnNames) - len(fields))
           self.send((recType, fields))
+          if header.len > 0:
+            print >> sys.stderr, "Warning: Broken header. Unprocessed data left in", recType.__class__.__name__, "record. Working around it."
+            self.inp.read(header.len)
+            header.len = 0
         else:
           self.inp.read(header.len)
         if count:


### PR DESCRIPTION
This works around someone else's bug where they write a Cn that is longer than 255 bytes. They actually write the long string but the U1 with the length overflows to some smaller number. Since the parser actually does the read operations, some data from the record is left unread and subsequent reads see garbage.

I think a better approach is to read each record's REC_LEN bytes first and have the parsers work on that data but the parser is very complicated and I wouldn't know where to begin making that change.
