### PR TITLE
Bugs fixed in Python 3

### DIFF
--- a/pystdf/IO.py
+++ b/pystdf/IO.py
@@ -51,7 +51,10 @@ class Parser(DataSource):
       raise EofException()
     header.len -= len(buf)
     val,=struct.unpack(self.endian + fmt, buf)
-    return val
+    if isinstance(val,bytes):
+        return val.decode("ascii")
+    else:
+        return val
 
   def readAndUnpackDirect(self, fmt):
     size = struct.calcsize(fmt)
@@ -84,7 +87,7 @@ class Parser(DataSource):
       raise EofException()
     header.len -= len(buf)
     val,=struct.unpack(str(slen) + "s", buf)
-    return val
+    return val.decode("ascii")
 
   def readBn(self, header):
     blen = self.readField(header, "U1")

--- a/pystdf/Writers.py
+++ b/pystdf/Writers.py
@@ -6,12 +6,12 @@
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
 # of the License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -31,7 +31,7 @@ def format_by_type(value, field_type):
         return str(value)
 
 class AtdfWriter:
-    
+
     @staticmethod
     def atdf_format(rectype, field_index, value):
         field_type = rectype.fieldStdfTypes[field_index]
@@ -49,21 +49,21 @@ class AtdfWriter:
                 return str(value)
         else:
             return str(value)
-    
+
     def __init__(self, stream=sys.stdout):
         self.stream = stream
-    
+
     def after_send(self, dataSource, data):
-        line = '%s:%s%s' % (data[0].__class__.__name__,
+        line = '%s:%s%s' % (data[0].__class__.__name__.upper(),
             '|'.join([self.atdf_format(data[0], i, val) for i, val in enumerate(data[1])]), '\n')
         self.stream.write(line)
-    
+
     def after_complete(self, dataSource):
         self.stream.flush()
 
 class XmlWriter:
     extra_entities = {'\0': ''}
-    
+
     @staticmethod
     def xml_format(rectype, field_index, value):
         field_type = rectype.fieldStdfTypes[field_index]
@@ -81,20 +81,20 @@ class XmlWriter:
                 return str(value)
         else:
             return str(value)
-    
+
     def __init__(self, stream=sys.stdout):
         self.stream = stream
-    
+
     def before_begin(self, dataSource):
         self.stream.write('<Stdf>\n')
-    
+
     def after_send(self, dataSource, data):
         self.stream.write('<%s' % (data[0].__class__.__name__))
         for i, val in enumerate(data[1]):
             fmtval = self.xml_format(data[0], i, val)
-            self.stream.write(' %s=%s' % (data[0].fieldNames[i], quoteattr(fmtval, self.extra_entities))) 
+            self.stream.write(' %s=%s' % (data[0].fieldNames[i], quoteattr(fmtval, self.extra_entities)))
         self.stream.write('/>\n')
-    
+
     def after_complete(self, dataSource):
         self.stream.write('</Stdf>\n')
         self.stream.flush()

--- a/pystdf/explorer/test.py
+++ b/pystdf/explorer/test.py
@@ -6,12 +6,12 @@
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
 # of the License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -24,83 +24,83 @@ from pystdf.IO import Parser
 from pystdf.Mapping import *
 from pystdf.Writers import *
 
-#--------------------------------------------------------------------------- 
-class HugeTable(gridlib.PyGridTableBase): 
-    def __init__(self, record_mapper, f): 
-        gridlib.PyGridTableBase.__init__(self) 
+#---------------------------------------------------------------------------
+class HugeTable(gridlib.PyGridTableBase):
+    def __init__(self, record_mapper, f):
+        gridlib.PyGridTableBase.__init__(self)
         self.record_mapper = record_mapper
         self.f = f
-        
-#        self.odd=gridlib.GridCellAttr() 
-#        self.odd.SetBackgroundColour("sky blue") 
-#        self.even=gridlib.GridCellAttr() 
-#        self.even.SetBackgroundColour("sea green") 
-    
-#    def GetAttr(self, row, col, kind): 
-#        attr = [self.even, self.odd][row % 2] 
-#        attr.IncRef() 
-#        return attr 
-     
-    # This is all it takes to make a custom data table to plug into a 
-    # wxGrid.  There are many more methods that can be overridden, but 
-    # the ones shown below are the required ones.  This table simply 
-    # provides strings containing the row and column values. 
-     
-    def GetNumberRows(self): 
+
+#        self.odd=gridlib.GridCellAttr()
+#        self.odd.SetBackgroundColour("sky blue")
+#        self.even=gridlib.GridCellAttr()
+#        self.even.SetBackgroundColour("sea green")
+
+#    def GetAttr(self, row, col, kind):
+#        attr = [self.even, self.odd][row % 2]
+#        attr.IncRef()
+#        return attr
+
+    # This is all it takes to make a custom data table to plug into a
+    # wxGrid.  There are many more methods that can be overridden, but
+    # the ones shown below are the required ones.  This table simply
+    # provides strings containing the row and column values.
+
+    def GetNumberRows(self):
         return len(self.record_mapper.indexes)
-    
-    def GetNumberCols(self): 
+
+    def GetNumberCols(self):
         return 2
-    
+
     def IsEmptyCell(self, row, col):
-        return False 
-    
+        return False
+
     value_getters = {
         0: lambda self, row: self.record_mapper.indexes[row],
         1: lambda self, row: self.record_mapper.types[row],
     }
-    
+
     def GetValue(self, row, col):
         return self.value_getters[col](self, row)
-    
-    def SetValue(self, row, col, value): 
+
+    def SetValue(self, row, col, value):
         pass
 
-#--------------------------------------------------------------------------- 
-class HugeTableGrid(gridlib.Grid): 
-    def __init__(self, parent, record_mapper, f): 
-        gridlib.Grid.__init__(self, parent, -1) 
-        table = HugeTable(record_mapper, f) 
-        # The second parameter means that the grid is to take ownership of the 
-        # table and will destroy it when done.  Otherwise you would need to keep 
-        # a reference to it and call it's Destroy method later. 
-        self.SetTable(table, True) 
-        self.Bind(gridlib.EVT_GRID_CELL_RIGHT_CLICK, self.OnRightDown)   
-    def OnRightDown(self, event): 
-        print "hello" 
-        print self.GetSelectedRows()
+#---------------------------------------------------------------------------
+class HugeTableGrid(gridlib.Grid):
+    def __init__(self, parent, record_mapper, f):
+        gridlib.Grid.__init__(self, parent, -1)
+        table = HugeTable(record_mapper, f)
+        # The second parameter means that the grid is to take ownership of the
+        # table and will destroy it when done.  Otherwise you would need to keep
+        # a reference to it and call it's Destroy method later.
+        self.SetTable(table, True)
+        self.Bind(gridlib.EVT_GRID_CELL_RIGHT_CLICK, self.OnRightDown)
+    def OnRightDown(self, event):
+        print("hello")
+        print(self.GetSelectedRows())
 
-#--------------------------------------------------------------------------- 
-class TestFrame(wx.Frame): 
+#---------------------------------------------------------------------------
+class TestFrame(wx.Frame):
     def __init__(self, parent, filename):
         f = open(filename, 'rb')
         p=Parser(inp=f)
         record_mapper = StreamMapper()
         p.addSink(record_mapper)
-        
-        print 'Parsing %s...' % (filename)
+
+        print('Parsing %s...' % (filename))
         p.parse()
-        print 'Parse complete'
-        
-        wx.Frame.__init__(self, parent, -1, "Huge (virtual) Table Demo", size=(640,480)) 
-        grid = HugeTableGrid(self, record_mapper, f) 
+        print('Parse complete')
+
+        wx.Frame.__init__(self, parent, -1, "Huge (virtual) Table Demo", size=(640,480))
+        grid = HugeTableGrid(self, record_mapper, f)
         grid.SetReadOnly(5,5, True)
 
-#--------------------------------------------------------------------------- 
-if __name__ == '__main__': 
-    import sys 
-    app = wx.PySimpleApp() 
-    frame = TestFrame(None, sys.argv[1]) 
-    frame.Show(True) 
-    app.MainLoop() 
-#--------------------------------------------------------------------------- 
+#---------------------------------------------------------------------------
+if __name__ == '__main__':
+    import sys
+    app = wx.PySimpleApp()
+    frame = TestFrame(None, sys.argv[1])
+    frame.Show(True)
+    app.MainLoop()
+#---------------------------------------------------------------------------


### PR DESCRIPTION
Fixed some bugs when porting from Python 2 to Python 3 (3.6):
- ```print``` function
- Exception syntax

Enhancements:
- For "binary" string, decode and return string without initial "b"
- Capitalize record types when output to Text, e.g. FTR instead of Ftr, for easy reading and consistent with STDF specs.