### PR TITLE
Rename ATDF writer to Text writer

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -13,7 +13,7 @@ record "events" in callback functions
 
 Refer to the provided command line scripts for ideas on how to use PySTDF:
 
-stdf_atdf, a PySTDF implementation of an STDF-to-ATDF converter.
+stdf2text, convert STDF to '|' delimited text format.
 stdf_slice, an example of how to seek to a specific record offset in the STDF.
 
 I have also included a very basic STDF viewer GUI, StdfExplorer.  I have plans 

--- a/pystdf/Writers.py
+++ b/pystdf/Writers.py
@@ -30,10 +30,10 @@ def format_by_type(value, field_type):
     else:
         return str(value)
 
-class AtdfWriter:
+class TextWriter:
 
     @staticmethod
-    def atdf_format(rectype, field_index, value):
+    def text_format(rectype, field_index, value):
         field_type = rectype.fieldStdfTypes[field_index]
         if value is None:
             return ""
@@ -55,7 +55,7 @@ class AtdfWriter:
 
     def after_send(self, dataSource, data):
         line = '%s:%s%s' % (data[0].__class__.__name__.upper(),
-            '|'.join([self.atdf_format(data[0], i, val) for i, val in enumerate(data[1])]), '\n')
+            '|'.join([self.text_format(data[0], i, val) for i, val in enumerate(data[1])]), '\n')
         self.stream.write(line)
 
     def after_complete(self, dataSource):

--- a/scripts/stdf2text
+++ b/scripts/stdf2text
@@ -33,14 +33,14 @@ except ImportError:
     have_bz2 = False
 
 from pystdf.IO import Parser
-from pystdf.Writers import AtdfWriter
+from pystdf.Writers import TextWriter
 import pystdf.V4
 
 gzPattern = re.compile('\.g?z', re.I)
 bz2Pattern = re.compile('\.bz2', re.I)
 
-def process_file(fn):
-    filename, = sys.argv[1:]
+def process_file(fnames):
+    filename = fnames[0]
 
     reopen_fn = None
     if filename is None:
@@ -60,12 +60,17 @@ def process_file(fn):
     else:
         f = open(filename, 'rb')
     p=Parser(inp=f, reopen_fn=reopen_fn)
-    p.addSink(AtdfWriter())
-    p.parse()
+    if len(fnames)<2:
+        p.addSink(TextWriter())
+        p.parse()
+    else:
+        with open(fnames[1],'w') as fout:
+            p.addSink(TextWriter(stream=fout))
+            p.parse()
     f.close()
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Usage: %s <stdf file>" % (sys.argv[0]))
     else:
-        process_file(sys.argv[1])
+        process_file(sys.argv[1:])


### PR DESCRIPTION
The AtdfWriter function and stdf2atdf script convert STDF to its text representation, not exactly in ATDF format (which has somewhat different specs from STDF). To avoid misunderstanding, I propose to rename them to TextWriter and stdf2text respectively.

One more minor change to allow users to convert STDF to a text file, instead of parsing all the text to the screen.