### PR TITLE
added missing parentheses

### DIFF
--- a/pystdf/explorer/record_pos_table.py
+++ b/pystdf/explorer/record_pos_table.py
@@ -26,7 +26,7 @@ class RecordPositionTable(gridlib.PyGridTableBase):
         self.record_mapper = record_mapper
         
     def GetNumberRows(self):
-        print 'GetNumberRows: %d' % (len(self.record_mapper.indexes))
+        print('GetNumberRows: %d' % (len(self.record_mapper.indexes)))
         return len(self.record_mapper.indexes)
     
     def GetNumberCols(self): 


### PR DESCRIPTION
For your review, error encountered 

```  
python setup.py install
running install
running build
running build_py
running build_scripts
running install_lib
byte-compiling C:\Users\mmendoza\AppData\Local\Continuum\Miniconda3\Lib\site-packages\pystdf\explorer\record_pos_table.py to record_pos_table.cpython-36.pyc
  File "C:\Users\mmendoza\AppData\Local\Continuum\Miniconda3\Lib\site-packages\pystdf\explorer\record_pos_table.py", line 29
    print 'GetNumberRows: %d' % (len(self.record_mapper.indexes))
                            ^
SyntaxError: invalid syntax

running install_scripts
running install_egg_info
Removing C:\Users\mmendoza\AppData\Local\Continuum\Miniconda3\Lib\site-packages\pystdf-1.3.2-py3.6.egg-info
Writing C:\Users\mmendoza\AppData\Local\Continuum\Miniconda3\Lib\site-packages\pystdf-1.3.2-py3.6.egg-info ```