### PR TITLE
Recover from a broken Cn (by Michael Fox, ported to Python 3)

### DIFF
--- a/pystdf/IO.py
+++ b/pystdf/IO.py
@@ -163,6 +163,13 @@ class Parser(DataSource):
           if len(fields) < len(recType.columnNames):
             fields += [None] * (len(recType.columnNames) - len(fields))
           self.send((recType, fields))
+          if header.len > 0:
+            print(
+              "Warning: Broken header. Unprocessed data left in record of type '%s'. Working around it." % recType.__class__.__name__,
+              file=sys.stderr,
+            )
+            self.inp.read(header.len)
+            header.len = 0
         else:
           self.inp.read(header.len)
         if count:


### PR DESCRIPTION
Assuming that the commit fbab53aa19d1aea43ff3ab2ace15058945f2e49 from https://github.com/cmars/pystdf/pull/1 is actually an improvement,

I ported it to Python 3 as was requested.