### PR TITLE
Fix bug where readField function is called without self

### DIFF
--- a/pystdf/IO.py
+++ b/pystdf/IO.py
@@ -93,7 +93,7 @@ class Parser(DataSource):
     blen = self.readField(header, "U1")
     bn = []
     for i in range(0, blen):
-      bn.append(readField(header, "B1"))
+      bn.append(self.readField(header, "B1"))
     return bn
 
   def readDn(self, header):


### PR DESCRIPTION
Currently, the code throws 

```
  File "/usr/local/lib/python3.7/site-packages/pystdf/IO.py", line 96, in readBn
    bn.append(readField(header, "B1"))
NameError: name 'readField' is not defined
```

Adding `self.` fixes the issue.