### PR TITLE
Want to read ANSI and not only ASCII char

### DIFF
--- a/pystdf/IO.py
+++ b/pystdf/IO.py
@@ -17,15 +17,14 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
-import sys
-
-import struct
 import re
+import struct
+import logging
 
-from pystdf.Types import *
 from pystdf import V4
-
 from pystdf.Pipeline import DataSource
+from pystdf.Types import *
+
 
 def appendFieldParser(fn, action):
   """Append a field parsing function to a record parsing function.
@@ -87,7 +86,13 @@ class Parser(DataSource):
       raise EofException()
     header.len -= len(buf)
     val,=struct.unpack(str(slen) + "s", buf)
-    return val.decode("ascii")
+    try:
+      return val.decode("ascii")
+    except UnicodeDecodeError:
+      try:
+        return val.decode("ansi")
+      except UnicodeDecodeError:
+        return ''.join([chr(c) if 32 <= c < 128 else '?' for c in val])
 
   def readBn(self, header):
     blen = self.readField(header, "U1")

--- a/pystdf/IO.py
+++ b/pystdf/IO.py
@@ -218,7 +218,7 @@ class Parser(DataSource):
         for recType in recTypes ])
 
     self.unpackMap = {
-      "C1": self.readField,
+      "C1": lambda header, fmt: self.readCn(header),
       "B1": self.readField,
       "U1": self.readField,
       "U2": self.readField,

--- a/pystdf/Writers.py
+++ b/pystdf/Writers.py
@@ -35,8 +35,7 @@ class TextWriter:
         self.stream = stream
         self.delimiter = delimiter
 
-    @staticmethod
-    def text_format(rectype, field_index, value):
+    def text_format(self, rectype, field_index, value):
         field_type = rectype.fieldStdfTypes[field_index]
         if value is None:
             return ""


### PR DESCRIPTION
Hi, 

I got STDF files with strings containing ANSI char like "70°C". It's not an issue as it's still only one-byte char.
But as it's over ord(127), it fails when using ASCII decoding.

Then I add 2 try-except cascade, to decode with ANSI if ASCII fail, and even replace char if ANSI fail.
My opinion is its better to be able to read a file with typo than not at all.


Also for DRY purposes, I don't want to duplicate above change, then I want to reuse Cn decoding for C1 token.

Hope that's clear.

PS : imports have been automatically refactored.