### PR TITLE
fix: parsing of Vn data type pad field (type 0)

### DIFF
--- a/pystdf/IO.py
+++ b/pystdf/IO.py
@@ -236,7 +236,7 @@ class Parser(DataSource):
         for recType in recTypes ])
 
     self.vnMap = {
-      0: lambda header: self.inp.read(header, 1),
+      0: lambda header: self.inp.read(1),
       1: lambda header: self.readField(header, "U1"),
       2: lambda header: self.readField(header, "U2"),
       3: lambda header: self.readField(header, "U4"),


### PR DESCRIPTION
Fixes #41.

@Allison1991 Could you please test this branch and confirm it fixes your issue? Or, if you attach an short STDF file example, I could add a test case. Thanks!