### PR TITLE
fix: Make method non-static

### DIFF
--- a/pystdf/Writers.py
+++ b/pystdf/Writers.py
@@ -35,8 +35,7 @@ class TextWriter:
         self.stream = stream
         self.delimiter = delimiter
 
-    @staticmethod
-    def text_format(rectype, field_index, value):
+    def text_format(self, rectype, field_index, value):
         field_type = rectype.fieldStdfTypes[field_index]
         if value is None:
             return ""


### PR DESCRIPTION
Fixes #17

It seems text_format is never used statically, so this should be safe to do.

